### PR TITLE
fix 2

### DIFF
--- a/yklibb/dist/YKLibb_basictable.js
+++ b/yklibb/dist/YKLibb_basictable.js
@@ -64,15 +64,13 @@ class BasicTable {
     this.sourceHeader = yklibbConfig.getHeader()
     this.indexOfHeaderId = 0
 
-    const [worksheet, totalRange, headerRange, dataRowsRange, nextDataRowsRange, header, totalValues, status] = Gssx.getHeaderAndDataFromWorksheet(spreadsheet.getSheetByName(sheetName), yklibbConfig)
-    this.worksheet = worksheet
+    const [header, values, headerRange, dataRowsRange, totalRange] = Gssx.getHeaderAndDataFromWorksheet(spreadsheet.getSheetByName(sheetName), yklibbConfig)
+
     this.totalRange = totalRange
     this.headerRange = headerRange
     this.dataRowsRange = dataRowsRange
-    this.nextDataRowsRange = nextDataRowsRange
     this.header = header
-    this.totalValues = totalValues
-    this.status = status
+    this.values = values
 
     if( dataRowsRange !== null ){
       this.sheetId = dataRowsRange.getSheet().getSheetId()

--- a/yklibb/dist/YKLibb_simpletable.js
+++ b/yklibb/dist/YKLibb_simpletable.js
@@ -25,10 +25,16 @@ class SimpleTable extends BasicTable{
     }
     else{
       this.dataRowsValues = []
-      this.nextDataRowsRange = this.headerRange.offset(1, 0, 1)
-      const rs2 = YKLiba.Range.getRangeShape(this.nextDataRowsRange)
-      YKLiblog.Log.debug(`SimpleTable constructor 2 rs=${JSON.stringify(rs2)}`)
-      this.status = 2
+      if(this.headerRange != null){
+        this.nextDataRowsRange = this.headerRange.offset(1, 0, 1)
+        const rs2 = YKLiba.Range.getRangeShape(this.nextDataRowsRange)
+        YKLiblog.Log.debug(`SimpleTable constructor 2 rs=${JSON.stringify(rs2)}`)
+        this.status = 2
+      }
+      else{
+        this.nextDataRowsRange = null
+        this.status = 3
+      }
     }
     this.arrayOfObjects = Util.createArrayOfObjects(this.dataRowsValues, this.header)
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Adapt `YKLibb_basictable.setup` to new `Gssx.getHeaderAndDataFromWorksheet` return signature**: now destructures `[header, values, headerRange, dataRowsRange, totalRange]`; assigns `values` and drops `worksheet`, `nextDataRowsRange`, `totalValues`, and `status` fields.
> - **Improve null safety in `YKLibb_simpletable` constructor**: only computes `nextDataRowsRange`/`status=2` when `headerRange` exists; otherwise sets `nextDataRowsRange=null` and `status=3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c2e4a834791d0e2b365106fc8877af3a99714fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->